### PR TITLE
Fix MQTT topic/region, proactive token refresh, reduce log noise

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,10 +51,14 @@ class DreameApp extends Homey.App {
       this._api.tenantId = tenantId;
     }
 
-    // Restore uid
+    // Restore uid and region
     const uid = this.homey.settings.get('uid');
     if (uid) {
       this._api.uid = uid;
+    }
+    const region = this.homey.settings.get('region');
+    if (region) {
+      this._api.region = region;
     }
 
     // Auto-save tokens whenever they change
@@ -65,6 +69,9 @@ class DreameApp extends Homey.App {
       this.homey.settings.set('tenantId', tokens.tenantId);
       if (tokens.uid) {
         this.homey.settings.set('uid', tokens.uid);
+      }
+      if (tokens.region) {
+        this.homey.settings.set('region', tokens.region);
       }
 
       // Update MQTT token if connected

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.dreame.vacuum.cloud",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "compatibility": ">=12.3.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/vacuum/device.js
+++ b/drivers/vacuum/device.js
@@ -357,6 +357,7 @@ const POLL_IDLE = 60000;       // MQTT connected + idle (safety net)
 const MQTT_STALE_MS = 120000;  // If no MQTT message for 2min during cleaning, fall back to fast poll
 const MAP_REFRESH_INTERVAL = 600000; // 10min — periodic map refresh via HTTP when MQTT is down
 const MQTT_RESTART_DELAY = 1800000;  // 30min — full MQTT restart after giving up
+const TOKEN_REFRESH_MARGIN = 100;    // seconds before expiry to proactively refresh (matches ioBroker)
 
 // Segment/room type names from Dreame protocol
 const SEGMENT_TYPE_NAMES = {
@@ -684,9 +685,8 @@ class DreameVacuumDevice extends Homey.Device {
       }
 
       const uid = api.uid;
-      const country = api.country || this.homey.settings.get('country') || 'eu';
+      const region = api.region || api.country || this.homey.settings.get('country') || 'eu';
       const model = this.getStoreValue('model') || '';
-      const masterUid = this.getStoreValue('masterUid') || uid;
 
       if (!uid || !api.accessToken || !this._bindDomain) {
         this._mqttRetryTimer = this.homey.setTimeout(() => this._connectMqtt(), 15000);
@@ -741,15 +741,18 @@ class DreameVacuumDevice extends Homey.Device {
       mqttClient.on('auth_error', listeners.auth_error);
       mqttClient.on('gave_up', listeners.gave_up);
 
+      if (MQTT_DEBUG) this.log(`[MQTT] Connecting: uid=${uid}, did=${this._did}, model=${model}, region=${region}, broker=${this._bindDomain}`);
       await mqttClient.connect({
         uid,
         accessToken: api.accessToken,
         bindDomain: this._bindDomain,
         did: this._did,
         model,
-        country,
-        masterUid,
+        country: region,
       });
+
+      // Start proactive token refresh to prevent auth expiry
+      this._startTokenRefreshTimer();
     } catch (e) {
       this.error('[MQTT] Connect error:', e.message);
       this._startMapRefreshTimer();
@@ -781,6 +784,49 @@ class DreameVacuumDevice extends Homey.Device {
     if (this._mqttRestartTimer) {
       this.homey.clearTimeout(this._mqttRestartTimer);
       this._mqttRestartTimer = null;
+    }
+  }
+
+  /**
+   * Start proactive token refresh timer.
+   * Refreshes token before expiry to prevent auth failures on MQTT and API.
+   * Matches ioBroker pattern: setInterval((expires_in - 100) * 1000).
+   */
+  _startTokenRefreshTimer() {
+    this._stopTokenRefreshTimer();
+    const api = this.homey.app.getApi();
+    if (!api || !api.tokenExpiry) return;
+
+    const msUntilRefresh = api.tokenExpiry - Date.now() - (TOKEN_REFRESH_MARGIN * 1000);
+    const delay = Math.max(msUntilRefresh, 60000); // At least 1 minute
+    if (MQTT_DEBUG) this.log(`[TOKEN] Proactive refresh scheduled in ${Math.round(delay / 1000)}s`);
+
+    this._tokenRefreshTimer = this.homey.setTimeout(async () => {
+      this._tokenRefreshTimer = null;
+      try {
+        const currentApi = this.homey.app.getApi();
+        if (!currentApi) return;
+        if (MQTT_DEBUG) this.log('[TOKEN] Proactive refresh triggered');
+        await currentApi.refreshAccessToken();
+        this.homey.app.saveUid(currentApi.uid);
+        // MQTT gets new token via onTokenUpdate → updateToken
+        // Schedule next refresh
+        this._startTokenRefreshTimer();
+      } catch (e) {
+        this.error('[TOKEN] Proactive refresh failed:', e.message);
+        // Retry in 5 minutes
+        this._tokenRefreshTimer = this.homey.setTimeout(() => {
+          this._tokenRefreshTimer = null;
+          this._startTokenRefreshTimer();
+        }, 300000);
+      }
+    }, delay);
+  }
+
+  _stopTokenRefreshTimer() {
+    if (this._tokenRefreshTimer) {
+      this.homey.clearTimeout(this._tokenRefreshTimer);
+      this._tokenRefreshTimer = null;
     }
   }
 
@@ -2059,6 +2105,7 @@ class DreameVacuumDevice extends Homey.Device {
   onDeleted() {
     this.stopPolling();
     this._stopMapRefreshTimer();
+    this._stopTokenRefreshTimer();
     this._cancelMqttRetryTimer();
     this._cancelMqttRestartTimer();
     // Only remove our listeners — don't disconnect the shared MQTT singleton

--- a/lib/DreameApi.js
+++ b/lib/DreameApi.js
@@ -18,6 +18,7 @@ class DreameApi {
     this.refreshToken = null;
     this.tenantId = '000000';
     this.uid = null;
+    this.region = country; // overwritten by login response if server returns different region
     this.tokenExpiry = 0;
     this._loginPromise = null;
     this._requestId = 0;
@@ -33,6 +34,7 @@ class DreameApi {
         tokenExpiry: this.tokenExpiry,
         tenantId: this.tenantId,
         uid: this.uid,
+        region: this.region,
       });
     }
   }
@@ -127,6 +129,7 @@ class DreameApi {
     this.refreshToken = data.refresh_token;
     this.tenantId = data.tenant_id || this.tenantId;
     this.uid = data.uid;
+    this.region = data.region || this.country;
     this.tokenExpiry = Date.now() + (data.expires_in * 1000);
     this._failCount = 0;
     this._notifyTokenUpdate();
@@ -232,6 +235,8 @@ class DreameApi {
           this._failCount += 1;
           throw err;
         }
+        // Progressive backoff between retries (500ms, 1000ms, ...)
+        await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
       }
     }
   }
@@ -358,7 +363,7 @@ class DreameApi {
         }
 
         if (downloadUrl) {
-          const mapResponse = await fetch(downloadUrl, { timeout: 30000 });
+          const mapResponse = await fetch(downloadUrl, { timeout: 60000 });
           if (!mapResponse.ok) {
             this._log(`[MAP-API] Download failed: ${mapResponse.status}`);
             continue;

--- a/lib/DreameMqtt.js
+++ b/lib/DreameMqtt.js
@@ -46,8 +46,7 @@ class DreameMqtt extends EventEmitter {
    * @param {string} opts.bindDomain  - e.g. "awsde0.iot.dreame.tech:8883"
    * @param {string} opts.did         - Device ID
    * @param {string} opts.model       - Device model e.g. "dreame.vacuum.p2259"
-   * @param {string} opts.country     - Country code e.g. "eu", "de", "us"
-   * @param {string} [opts.masterUid] - Master/owner UID (defaults to uid)
+   * @param {string} opts.country     - Region/country code e.g. "eu", "de", "us"
    */
   async connect(opts) {
     this._destroyClient();
@@ -55,7 +54,6 @@ class DreameMqtt extends EventEmitter {
     this._stopped = false;
     this._config = { ...opts };
     const { uid, accessToken, bindDomain, did, model, country } = opts;
-    const masterUid = opts.masterUid || uid;
 
     if (!uid || !accessToken || !bindDomain) {
       throw new Error('MQTT connect requires uid, accessToken and bindDomain');
@@ -64,12 +62,12 @@ class DreameMqtt extends EventEmitter {
     // Parse broker host/port from bindDomain
     const [brokerHost, brokerPortStr] = bindDomain.split(':');
     const brokerPort = parseInt(brokerPortStr, 10) || 8883;
-    const brokerHostBase = brokerHost.split('.')[0];
 
-    const agentId = crypto.randomBytes(4).toString('hex');
-    const clientIdStr = `p_${uid}_${agentId}_${brokerHostBase}`;
+    // Simple random clientId matching ioBroker.dreamehome format
+    const clientIdStr = `p_${crypto.randomBytes(8).toString('hex')}`;
 
-    this._topic = `/status/${did}/${masterUid}/${model}/${country}/`;
+    // Topic uses logged-in user's uid (not device owner's uid) — matches ioBroker/Dreame app behavior
+    this._topic = `/status/${did}/${uid}/${model}/${country}/`;
 
     const brokerUrl = `mqtts://${brokerHost}:${brokerPort}`;
     const myClientId = ++this._clientId;


### PR DESCRIPTION
- MQTT topic uses logged-in user uid instead of device owner masterUid
- Use API-returned region instead of configured country code
- Simplify clientId to random hex (matching ioBroker pattern)
- Proactive token refresh timer (100s before expiry, like ioBroker)
- Progressive retry backoff on API requests (500ms * attempt)
- Increase map download timeout to 60s
- Gate verbose MQTT/token logs behind MQTT_DEBUG flag
- Persist and restore region from app settings