### PR TITLE
Add manual room ID flow cards as alternative to autocomplete

### DIFF
--- a/.homeycompose/flow/actions/start_multi_room_cleaning_by_id.json
+++ b/.homeycompose/flow/actions/start_multi_room_cleaning_by_id.json
@@ -1,0 +1,63 @@
+{
+  "title": {
+    "en": "Clean multiple rooms by ID"
+  },
+  "titleFormatted": {
+    "en": "Clean room IDs [[room_ids]] at [[suction]] suction, [[water]] water, [[repeats]]x"
+  },
+  "hint": {
+    "en": "Clean multiple rooms by entering comma-separated room IDs. Find room IDs in the app settings page."
+  },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=vacuum"
+    },
+    {
+      "type": "text",
+      "name": "room_ids",
+      "title": {
+        "en": "Room IDs"
+      },
+      "placeholder": {
+        "en": "e.g. 10,12,14"
+      }
+    },
+    {
+      "type": "dropdown",
+      "name": "suction",
+      "title": {
+        "en": "Suction"
+      },
+      "values": [
+        { "id": "quiet", "title": { "en": "Quiet" } },
+        { "id": "standard", "title": { "en": "Standard" } },
+        { "id": "strong", "title": { "en": "Strong" } },
+        { "id": "turbo", "title": { "en": "Turbo" } }
+      ]
+    },
+    {
+      "type": "dropdown",
+      "name": "water",
+      "title": {
+        "en": "Water Volume"
+      },
+      "values": [
+        { "id": "low", "title": { "en": "Low" } },
+        { "id": "medium", "title": { "en": "Medium" } },
+        { "id": "high", "title": { "en": "High" } }
+      ]
+    },
+    {
+      "type": "number",
+      "name": "repeats",
+      "title": {
+        "en": "Repeats"
+      },
+      "min": 1,
+      "max": 3,
+      "step": 1
+    }
+  ]
+}

--- a/.homeycompose/flow/actions/start_room_cleaning_by_id.json
+++ b/.homeycompose/flow/actions/start_room_cleaning_by_id.json
@@ -1,0 +1,63 @@
+{
+  "title": {
+    "en": "Clean room by ID"
+  },
+  "titleFormatted": {
+    "en": "Clean room ID [[room_id]] at [[suction]] suction, [[water]] water, [[repeats]]x"
+  },
+  "hint": {
+    "en": "Start cleaning a room by its numeric ID. Find room IDs in the app settings page."
+  },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=vacuum"
+    },
+    {
+      "type": "text",
+      "name": "room_id",
+      "title": {
+        "en": "Room ID"
+      },
+      "placeholder": {
+        "en": "e.g. 10"
+      }
+    },
+    {
+      "type": "dropdown",
+      "name": "suction",
+      "title": {
+        "en": "Suction"
+      },
+      "values": [
+        { "id": "quiet", "title": { "en": "Quiet" } },
+        { "id": "standard", "title": { "en": "Standard" } },
+        { "id": "strong", "title": { "en": "Strong" } },
+        { "id": "turbo", "title": { "en": "Turbo" } }
+      ]
+    },
+    {
+      "type": "dropdown",
+      "name": "water",
+      "title": {
+        "en": "Water Volume"
+      },
+      "values": [
+        { "id": "low", "title": { "en": "Low" } },
+        { "id": "medium", "title": { "en": "Medium" } },
+        { "id": "high", "title": { "en": "High" } }
+      ]
+    },
+    {
+      "type": "number",
+      "name": "repeats",
+      "title": {
+        "en": "Repeats"
+      },
+      "min": 1,
+      "max": 3,
+      "step": 1
+    }
+  ]
+}

--- a/.homeycompose/flow/conditions/is_cleaning_room_by_id.json
+++ b/.homeycompose/flow/conditions/is_cleaning_room_by_id.json
@@ -1,0 +1,28 @@
+{
+  "title": {
+    "en": "Is cleaning room by ID..."
+  },
+  "titleFormatted": {
+    "en": "Is cleaning room ID [[room_id]]"
+  },
+  "hint": {
+    "en": "Check if the vacuum is currently cleaning a specific room by its numeric ID"
+  },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=vacuum"
+    },
+    {
+      "type": "text",
+      "name": "room_id",
+      "title": {
+        "en": "Room ID"
+      },
+      "placeholder": {
+        "en": "e.g. 10"
+      }
+    }
+  ]
+}

--- a/.homeycompose/flow/triggers/room_cleaning_finished_by_id.json
+++ b/.homeycompose/flow/triggers/room_cleaning_finished_by_id.json
@@ -1,0 +1,42 @@
+{
+  "title": {
+    "en": "Room cleaning finished (by ID)"
+  },
+  "titleFormatted": {
+    "en": "Room ID [[room_id]] cleaning finished"
+  },
+  "hint": {
+    "en": "Triggers when the vacuum finishes cleaning a specific room. Enter a room ID or leave empty for any room."
+  },
+  "tokens": [
+    {
+      "name": "room_name",
+      "type": "string",
+      "title": { "en": "Room name" },
+      "example": { "en": "Living Room" }
+    },
+    {
+      "name": "room_id",
+      "type": "string",
+      "title": { "en": "Room ID" },
+      "example": { "en": "10" }
+    }
+  ],
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=vacuum"
+    },
+    {
+      "type": "text",
+      "name": "room_id",
+      "title": {
+        "en": "Room ID"
+      },
+      "placeholder": {
+        "en": "Leave empty for any room"
+      }
+    }
+  ]
+}

--- a/.homeycompose/flow/triggers/room_cleaning_started_by_id.json
+++ b/.homeycompose/flow/triggers/room_cleaning_started_by_id.json
@@ -1,0 +1,42 @@
+{
+  "title": {
+    "en": "Room cleaning started (by ID)"
+  },
+  "titleFormatted": {
+    "en": "Room ID [[room_id]] cleaning started"
+  },
+  "hint": {
+    "en": "Triggers when the vacuum starts cleaning a specific room. Enter a room ID or leave empty for any room."
+  },
+  "tokens": [
+    {
+      "name": "room_name",
+      "type": "string",
+      "title": { "en": "Room name" },
+      "example": { "en": "Living Room" }
+    },
+    {
+      "name": "room_id",
+      "type": "string",
+      "title": { "en": "Room ID" },
+      "example": { "en": "10" }
+    }
+  ],
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=vacuum"
+    },
+    {
+      "type": "text",
+      "name": "room_id",
+      "title": {
+        "en": "Room ID"
+      },
+      "placeholder": {
+        "en": "Leave empty for any room"
+      }
+    }
+  ]
+}

--- a/drivers/vacuum/device.js
+++ b/drivers/vacuum/device.js
@@ -1814,21 +1814,31 @@ class DreameVacuumDevice extends Homey.Device {
 
   _fireRoomStartedTriggers(roomIds) {
     const triggerCard = this.homey.flow.getDeviceTriggerCard('room_cleaning_started');
+    const triggerByIdCard = this.homey.flow.getDeviceTriggerCard('room_cleaning_started_by_id');
     for (const roomId of roomIds) {
       const room = this._rooms.find(r => r.id === roomId);
       const roomName = room ? room.name : `Room ${roomId}`;
-      triggerCard.trigger(this, { room_name: roomName }, { room_id: roomId })
+      const tokens = { room_name: roomName, room_id: String(roomId) };
+      const state = { room_id: roomId };
+      triggerCard.trigger(this, { room_name: roomName }, state)
         .catch(e => this.error('Room start trigger:', e));
+      triggerByIdCard.trigger(this, tokens, state)
+        .catch(e => this.error('Room start by-id trigger:', e));
     }
   }
 
   _fireRoomFinishedTriggers() {
     const triggerCard = this.homey.flow.getDeviceTriggerCard('room_cleaning_finished');
+    const triggerByIdCard = this.homey.flow.getDeviceTriggerCard('room_cleaning_finished_by_id');
     for (const roomId of this._cleaningRoomIds) {
       const room = this._rooms.find(r => r.id === roomId);
       const roomName = room ? room.name : `Room ${roomId}`;
-      triggerCard.trigger(this, { room_name: roomName }, { room_id: roomId })
+      const tokens = { room_name: roomName, room_id: String(roomId) };
+      const state = { room_id: roomId };
+      triggerCard.trigger(this, { room_name: roomName }, state)
         .catch(e => this.error('Room finish trigger:', e));
+      triggerByIdCard.trigger(this, tokens, state)
+        .catch(e => this.error('Room finish by-id trigger:', e));
     }
     this._cleaningRoomIds = [];
   }

--- a/drivers/vacuum/driver.js
+++ b/drivers/vacuum/driver.js
@@ -268,6 +268,41 @@ class DreameVacuumDriver extends Homey.Driver {
     roomFinishedCard.registerArgumentAutocompleteListener('room', async (query, args) => {
       return this._getRoomAutocompleteWithAny(query, args);
     });
+
+    // --- Manual room ID cards (text input, no autocomplete) ---
+
+    this.homey.flow.getActionCard('start_room_cleaning_by_id')
+      .registerRunListener(async (args) => {
+        const roomId = parseInt(args.room_id, 10);
+        if (isNaN(roomId) || roomId <= 0) throw new Error('Invalid room ID');
+        await args.device.startRoomCleaning(roomId, args.repeats, args.suction, args.water);
+      });
+
+    this.homey.flow.getActionCard('start_multi_room_cleaning_by_id')
+      .registerRunListener(async (args) => {
+        const roomIds = String(args.room_ids).split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id) && id > 0);
+        if (roomIds.length === 0) throw new Error('No valid room IDs provided');
+        await args.device.startMultiRoomCleaning(roomIds, args.repeats, args.suction, args.water);
+      });
+
+    this.homey.flow.getConditionCard('is_cleaning_room_by_id')
+      .registerRunListener(async (args) => {
+        const roomId = parseInt(args.room_id, 10);
+        if (isNaN(roomId) || roomId <= 0) throw new Error('Invalid room ID');
+        return args.device.isCleaningRoom(roomId);
+      });
+
+    const roomStartedByIdCard = this.homey.flow.getDeviceTriggerCard('room_cleaning_started_by_id');
+    roomStartedByIdCard.registerRunListener(async (args, state) => {
+      if (!args.room_id || args.room_id.trim() === '') return true;
+      return String(state.room_id) === String(args.room_id).trim();
+    });
+
+    const roomFinishedByIdCard = this.homey.flow.getDeviceTriggerCard('room_cleaning_finished_by_id');
+    roomFinishedByIdCard.registerRunListener(async (args, state) => {
+      if (!args.room_id || args.room_id.trim() === '') return true;
+      return String(state.room_id) === String(args.room_id).trim();
+    });
   }
 
   async onPair(session) {


### PR DESCRIPTION
Clones all room-based flow cards (actions, triggers, conditions) with text input for room IDs instead of autocomplete dropdown. Useful when rooms are not yet discovered or users prefer entering IDs directly.

New cards:
- Clean room by ID (single)
- Clean multiple rooms by ID (comma-separated)
- Room cleaning started/finished by ID (triggers)
- Is cleaning room by ID (condition)